### PR TITLE
Enable Remote Wakeup in configuration descriptor

### DIFF
--- a/adafruit_usb_descriptor/standard.py
+++ b/adafruit_usb_descriptor/standard.py
@@ -176,9 +176,9 @@ class ConfigurationDescriptor:
                  bNumInterfaces,
                  bConfigurationValue=0x1,
                  iConfiguration=0,
-                 # bus powered (bit 6), no remote wakeup (bit 5),
+                 # bus powered (bit 6), remote wakeup (bit 5),
                  # bit 7 is always 1 and 0-4 are always 0
-                 bmAttributes=0x80,
+                 bmAttributes=0xA0,
                  # 100 mA by default (50 means 100ma)
                  bMaxPower=50):
         self.description = description


### PR DESCRIPTION
remote wakeup is supported by tinyusb since https://github.com/hathach/tinyusb/pull/51 . This must be reported as supported in configuration descriptor attribute first.

PS: couldn't pick reviewer, tagging @dhalbert instead :smile: 