### PR TITLE
Don't increment endpoint if none used

### DIFF
--- a/adafruit_usb_descriptor/util.py
+++ b/adafruit_usb_descriptor/util.py
@@ -38,14 +38,17 @@ def join_interfaces(args, *, renumber_endpoints=True):
             interface.bInterfaceNumber = interfaces.index(interface)
             max_endpoint_address = base_endpoint_number
             for subdescriptor in interface.subdescriptors:
+                endpoint_used = False
                 if (subdescriptor.bDescriptorType ==
                         standard.EndpointDescriptor.bDescriptorType):
                     if renumber_endpoints:
+                        endpoint_used = True
                         subdescriptor.bEndpointAddress += base_endpoint_number
                         endpoint_address = subdescriptor.bEndpointAddress & 0xf
                         max_endpoint_address = max(max_endpoint_address,
                                                 endpoint_address)
                     elif subdescriptor.bEndpointAddress == 0:
                         raise ValueError('Endpoint address must not be 0')
-            base_endpoint_number = max_endpoint_address + 1
+            if endpoint_used:
+                base_endpoint_number = max_endpoint_address + 1
     return interfaces


### PR DESCRIPTION
The endpoint renumering code would always increment the endpoint even if no endpoint descriptors were present. This caused an endpoint pair to be skipped in some cases.

With this fix, there are now enough endpoints on most boards with 8 endpoint pairs to add a secondary CDC device without turning any other device off. The exception is SAMD21, which [needs two MSC endpoints](https://github.com/adafruit/circuitpython/pull/2116/commits/195de97c67c4d1daa6ec8659bbdf30b8e7f4fff6).